### PR TITLE
feat(response-classes): create response classes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,54 @@
+{
+  "root": true,
+  "env": {
+    "es6": true,
+    "node": true,
+    "mocha": true
+  },
+  "extends": ["airbnb-base"],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "rules": {
+    "comma-dangle": 0,
+    "consistent-return": 0,
+    "curly": ["error", "multi-line"],
+    "eofline": "always",
+    "import/no-unresolved": [2, { "commonjs": 2 }],
+    "indent": [2, 2],
+    "max-len": ["error", { "code": 110 }],
+    "new-cap": 0,
+    "no-console": 2,
+    "no-param-reassign": 0,
+    "no-shadow": ["error", { "allow": ["req", "res", "err"] }],
+    "no-unused-vars": ["error", { "varsIgnorePattern": "should|expect" }],
+    "one-var": 0,
+    "one-var-declaration-per-line": 0,
+    "require-jsdoc": [
+      "error",
+      {
+        "require": {
+          "FunctionDeclaration": true,
+          "MethodDefinition": true,
+          "ClassDeclaration": true,
+          "ArrowFunctionExpression": true
+        }
+      }
+    ],
+    "semicolon": [true, "always"],
+    "valid-jsdoc": [
+      "error",
+      {
+        "requireReturn": true,
+        "requireReturnType": true,
+        "requireParamDescription": false,
+        "requireReturnDescription": true
+      }
+    ]
+  }
+}

--- a/src/response/errorResponse.js
+++ b/src/response/errorResponse.js
@@ -1,0 +1,62 @@
+const commonFields = {
+  status: 'error',
+  data: 'null'
+};
+
+/**
+ * @class ErrorResponse
+ */
+module.exports = class ErrorResponse {
+  /**
+   *@static
+   * @param {string} field the missing field
+   * @returns {object} a response object
+   */
+  static missingRequiredField(field) {
+    const message = `${field} is required.`;
+    return {
+      message,
+      ...commonFields
+    };
+  }
+
+  /**
+   * @static
+   * @param {string} field input field
+   * @param {string} type input field type
+   * @returns {object} a response object
+   */
+  static wrongFieldType(field, type) {
+    const indefiniteArticle = type === 'string' ? 'a' : 'an';
+    const message = `${field} should be ${indefiniteArticle} ${type}.`;
+    return {
+      message,
+      ...commonFields
+    };
+  }
+
+  /**
+   * @static
+   * @returns {object} a response object
+   */
+  static invalidJSON() {
+    const message = 'invalid JSON payload passed.';
+    return {
+      message,
+      ...commonFields
+    };
+  }
+
+  /**
+   * @static
+   * @param {string} field missing field from data
+   * @returns {object} a response object
+   */
+  static missingFieldFromData(field) {
+    const message = `field ${field} is missing from data.`;
+    return {
+      message,
+      ...commonFields
+    };
+  }
+};

--- a/src/response/index.js
+++ b/src/response/index.js
@@ -1,0 +1,7 @@
+const ErrorResponse = require('./errorResponse');
+const ValidationResponse = require('./validationResponse');
+
+module.exports = {
+  ErrorResponse,
+  ValidationResponse
+};

--- a/src/response/validationResponse.js
+++ b/src/response/validationResponse.js
@@ -1,0 +1,36 @@
+/* eslint-disable camelcase */
+
+/**
+ * @class ValidationResponse
+ */
+module.exports = class ValidationResponse {
+  /**
+   *
+   * @param {string} status the status (success or error)
+   * @param {object} validationData validation data object
+   * @returns {object} a validation response object
+   */
+  static getResponseObject(status, validationData) {
+    const {
+      field, field_value, condition, condition_value
+    } = validationData;
+    const successMessage = `field ${field} successfully validated.`;
+    const errorMessage = `field ${field} failed validation.`;
+
+    const error = status !== 'success';
+    const message = status === 'success' ? successMessage : errorMessage;
+    return {
+      message,
+      status,
+      data: {
+        validation: {
+          error,
+          field,
+          field_value,
+          condition,
+          condition_value
+        }
+      }
+    };
+  }
+};


### PR DESCRIPTION
#### What does this PR do?

This pull request creates classes containing functions that returns error or success response objects, as required

#### Description of Task proposed in this pull request?

The following files were added:
* errorResponse.js
* validationResponse.js
* index.js (the aggregator file)
